### PR TITLE
updated instructions for .env and compose files when using non standard port in redis

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,7 @@ POSTGRES_PASSWORD=password
 
 # If not using docker, you probably want to set this to "localhost"
 # REDIS_HOST=localhost
+# For changing port change port here and in docker-compose file
 REDIS_HOST=redis
 REDIS_PORT=6379
 REDIS_PASSWORD=

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -34,12 +34,14 @@ services:
     container_name: postgres
 
   ### Redis ################################################
+  ### Use a different port in ports and command section  ###
+  ### to use another port. Also change port in .env file ###
   redis:
     image: redis:6-alpine
     ports:
       - "6379:6379"
     container_name: redis
-    command: redis-server --save "" --appendonly no
+    command: redis-server --save "" --appendonly no --port 6379
     
 volumes:
   postgres-data:


### PR DESCRIPTION
Redis might require passing port value in commands section (in compose file) when using non standard ports. Added instructions for achieving the same. Should not be a breaking change. Tested with both configs works as expected. 